### PR TITLE
FE: Create generic address summary, address form components

### DIFF
--- a/front-end/components/AddressForm.js
+++ b/front-end/components/AddressForm.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { StyleSheet, View, Text } from 'react-native';
-import { Input, Button } from 'react-native-elements';
+import { StyleSheet, View } from 'react-native';
+import { TextField } from 'react-native-material-textfield';
 import Colors from '../constants/Colors';
 import commonStyles from '../constants/commonStyles';
 import PropTypes from 'prop-types';
 
-const addressFormLabel = {
+const addressFormType = {
   name: 'name',
   address: 'address',
   postCode: 'postCode',
@@ -19,98 +19,146 @@ export default function AddressForm({
   postCode,
   city,
   phoneNumber,
-  onAddressInputChange,
+  onAddressInputEndEditing,
 }) {
   return (
     <View style={styles.formContainer}>
-      <Input
+      <TextField
         label={'Full name'}
+        textColor={Colors.black}
+        fontSize={12}
+        labelFontSize={10}
+        lineWidth={0.5}
+        activeLineWidth={1}
+        tintColor={Colors.mediumCarmine}
+        baseColor={Colors.mediumBlack}
+        errorColor={Colors.mediumCarmine}
         inputContainerStyle={styles.inputContainer}
-        labelStyle={styles.inputLabel}
-        inputStyle={styles.inputValue}
+        labelTextStyle={styles.inputLabel}
         defaultValue={name}
-        onChangeText={text =>
-          onAddressInputChange({ label: addressFormLabel.name, value: text })
+        onEndEditing={event =>
+          onAddressInputEndEditing({
+            type: addressFormType.name,
+            value: event.nativeEvent.text,
+          })
         }
       />
-      <Input
+      <TextField
         label={'Street and house number'}
-        containerStyle={styles.inputFieldContainer}
+        textColor={Colors.black}
+        fontSize={12}
+        labelFontSize={10}
+        lineWidth={0.5}
+        activeLineWidth={1}
+        tintColor={Colors.mediumCarmine}
+        baseColor={Colors.mediumBlack}
+        errorColor={Colors.mediumCarmine}
         inputContainerStyle={styles.inputContainer}
-        labelStyle={styles.inputLabel}
-        inputStyle={styles.inputValue}
-        backgroundColor={'transparent'}
+        labelTextStyle={styles.inputLabel}
         defaultValue={address}
-        onChangeText={text =>
-          onAddressInputChange({ label: addressFormLabel.address, value: text })
+        onEndEditing={event =>
+          onAddressInputEndEditing({
+            type: addressFormType.address,
+            value: event.nativeEvent.text,
+          })
         }
       />
-      <View style={{flexDirection: 'row', justifyContent: 'space-between'}}>
-        <Input
+      <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
+        <TextField
           label={'Postcode'}
-          containerStyle={[styles.inputFieldContainer, styles.smallInputContainer]}
+          textColor={Colors.black}
+          fontSize={12}
+          labelFontSize={10}
+          lineWidth={0.5}
+          activeLineWidth={1}
+          tintColor={Colors.mediumCarmine}
+          baseColor={Colors.mediumBlack}
+          errorColor={Colors.mediumCarmine}
           inputContainerStyle={styles.inputContainer}
-          labelStyle={styles.inputLabel}
-          inputStyle={styles.inputValue}
-          backgroundColor={'transparent'}
-          defaultValue={postCode}
-          onChangeText={text =>
-            onAddressInputChange({ label: addressFormLabel.postCode, value: text })
+          labelTextStyle={styles.inputLabel}
+          containerStyle={styles.smallInputContainer}
+          defaultValue={postCode && postCode.toString()}
+          onEndEditing={event =>
+            onAddressInputEndEditing({
+              type: addressFormType.postCode,
+              value: event.nativeEvent.text,
+            })
           }
         />
-        <Input
+        <TextField
           label={'City (Finland only)'}
-          containerStyle={[styles.inputFieldContainer, styles.smallInputContainer]}
+          textColor={Colors.black}
+          fontSize={12}
+          labelFontSize={10}
+          lineWidth={0.5}
+          activeLineWidth={1}
+          tintColor={Colors.mediumCarmine}
+          baseColor={Colors.mediumBlack}
+          errorColor={Colors.mediumCarmine}
           inputContainerStyle={styles.inputContainer}
-          labelStyle={styles.inputLabel}
-          inputStyle={styles.inputValue}
-          backgroundColor={'transparent'}
+          labelTextStyle={styles.inputLabel}
+          containerStyle={styles.smallInputContainer}
           defaultValue={city}
-          onChangeText={text =>
-            onAddressInputChange({ label: addressFormLabel.city, value: text })
+          onEndEditing={event =>
+            onAddressInputEndEditing({
+              type: addressFormType.city,
+              value: event.nativeEvent.text,
+            })
           }
         />
       </View>
-      <Input
+      <TextField
         label={'Phone number'}
-        containerStyle={styles.inputFieldContainer}
+        textColor={Colors.black}
+        fontSize={12}
+        labelFontSize={10}
+        lineWidth={0.5}
+        activeLineWidth={1}
+        tintColor={Colors.mediumCarmine}
+        baseColor={Colors.mediumBlack}
+        errorColor={Colors.mediumCarmine}
         inputContainerStyle={styles.inputContainer}
-        labelStyle={styles.inputLabel}
-        inputStyle={styles.inputValue}
-        backgroundColor={'transparent'}
+        labelTextStyle={styles.inputLabel}
         defaultValue={phoneNumber}
-        onChangeText={text =>
-          onAddressInputChange({ label: addressFormLabel.phoneNumber, value: text })
+        onEndEditing={event =>
+          onAddressInputEndEditing({
+            type: addressFormType.phoneNumber,
+            value: event.nativeEvent.text,
+          })
         }
       />
     </View>
   );
 }
 
+AddressForm.propTypes = {
+  name: PropTypes.string,
+  address: PropTypes.string,
+  postCode: PropTypes.number,
+  city: PropTypes.string,
+  phoneNumber: PropTypes.string,
+  onAddressInputEndEditing: PropTypes.func,
+};
+
+AddressForm.defaultProps = {
+  name: '',
+  address: '',
+  city: '',
+  phoneNumber: '',
+  onAddressInputEndEditing: ({ type, value }) => {},
+};
+
 const styles = StyleSheet.create({
-  inputFieldContainer: {
-    marginTop: 18
-  },
   inputContainer: {
-    borderBottomWidth: 1,
-    borderBottomColor: Colors.lightGrey,
-    paddingLeft: 2,
-    height: 24
+    marginTop: -8,
+    paddingTop: 36,
+    height: 58,
   },
   smallInputContainer: {
-    width: 150
+    width: 130,
   },
   inputLabel: {
     ...commonStyles.fontRalewayMedium,
-    ...commonStyles.textGrey,
-    fontSize: 10,
-    paddingLeft: 2,
-    marginBottom: 4
-  },
-  inputValue: {
-    ...commonStyles.fontRalewayMedium,
-    ...commonStyles.textBlack,
-    fontSize: 12,
-    borderWidth: 0
+    ...commonStyles.black,
   },
 });

--- a/front-end/components/AddressSummary.js
+++ b/front-end/components/AddressSummary.js
@@ -6,15 +6,28 @@ import commonStyles from '../constants/commonStyles';
 import PropTypes from 'prop-types';
 import AddressForm from './AddressForm';
 
-const hitSlop = { top: 20, bottom: 20, left: 20, right: 20 };
-
 export default class AddressSummary extends React.Component {
   state = {
     isEditing: false,
+    saveButtonEnabled: false,
   };
 
-  switchToEditMode = () => {
-    this.setState({ isEditing: true });
+  toggleEditMode = () => {
+    this.setState({ isEditing: !this.state.isEditing });
+  };
+
+  onAddressInputEndEditing = ({ type, value }) => {
+    //Validate input here, then return error message to AddressForm
+    console.log(`${type}: ${value}`);
+    //Validate form to see if save button should be enabled
+    if (this.validateForm()) {
+      this.setState({ saveButtonEnabled: true });
+    }
+  };
+
+  validateForm = () => {
+    // Check if all form input is filled (not empty)
+    return false;
   };
 
   render() {
@@ -22,18 +35,15 @@ export default class AddressSummary extends React.Component {
       <View>
         {this.props.canEditAddress && (
           <TouchableOpacity
-            onPress={this.switchToEditMode}
-            hitSlop={hitSlop}
+            onPress={this.toggleEditMode}
             style={{ zIndex: 100 }}
           >
-            <View>
-              <Icon
-                name={this.state.isEditing ? 'close' : 'edit'}
-                size={10}
-                color={Colors.white}
-                containerStyle={styles.editIconContainer}
-              />
-            </View>
+            <Icon
+              name={this.state.isEditing ? 'close' : 'edit'}
+              size={12}
+              color={Colors.white}
+              containerStyle={styles.editIconContainer}
+            />
           </TouchableOpacity>
         )}
         <View
@@ -48,25 +58,41 @@ export default class AddressSummary extends React.Component {
         >
           {this.state.isEditing ? (
             <View style={styles.formContainer}>
-              <AddressForm name={'Thanh Dang'} address={'Kotkantie 1'} onAddressInputChange={({label, value}) => {}}/>
+              <AddressForm
+                name={this.props.name}
+                {...this.props.shippingAddress}
+                phoneNumber={this.props.phoneNumber}
+                onAddressInputEndEditing={this.onAddressInputEndEditing}
+              />
+              <Button
+                title={'Save'}
+                titleStyle={styles.buttonTitleDefaultStyle}
+                buttonStyle={[
+                  styles.buttonDefaultStyle,
+                  this.state.saveButtonEnabled
+                    ? styles.activeButton
+                    : styles.disabledButton,
+                ]}
+                containerStyle={styles.formSaveButtonContainer}
+                onPress={this.props.onPressSaveAddressForm}
+              />
             </View>
           ) : (
             <View style={styles.addressSummaryContainer}>
               <View style={styles.addressDetailsContainer}>
                 <Text style={styles.importantText}>{this.props.name}</Text>
                 <Text style={styles.defaultText}>
-                  {this.props.shippingAddress}
+                  {Object.values(this.props.shippingAddress).join(', ')}
                 </Text>
                 <Text style={styles.defaultText}>{this.props.phoneNumber}</Text>
               </View>
               {this.props.hasSelectedButton && (
-                <View style={styles.buttonContainer}>
+                <View style={styles.selectButtonContainer}>
                   <Button
                     type={this.props.isButtonSelected ? 'solid' : 'outline'}
                     title={this.props.isButtonSelected ? 'Selected' : 'Select'}
                     titleStyle={[
-                      commonStyles.fontRalewaySemiBold,
-                      { fontSize: 14 },
+                      styles.buttonTitleDefaultStyle,
                       this.props.isButtonSelected
                         ? commonStyles.textWhite
                         : commonStyles.textMacaroniCheese,
@@ -77,7 +103,7 @@ export default class AddressSummary extends React.Component {
                         ? styles.activeButton
                         : styles.nonActiveButton,
                     ]}
-                    onPress={this.props.onPressButtonSelected}
+                    onPress={this.props.onPressSelectedButton}
                   />
                 </View>
               )}
@@ -88,6 +114,32 @@ export default class AddressSummary extends React.Component {
     );
   }
 }
+
+AddressSummary.propTypes = {
+  name: PropTypes.string,
+  shippingAddress: PropTypes.shape({
+    address: PropTypes.string,
+    postCode: PropTypes.number,
+    city: PropTypes.string,
+  }),
+  phoneNumber: PropTypes.string,
+  hasSelectedButton: PropTypes.bool,
+  isButtonSelected: PropTypes.bool,
+  onPressSelectedButton: PropTypes.func,
+  canEditAddress: PropTypes.bool,
+  onPressSaveAddressForm: PropTypes.func,
+};
+
+AddressSummary.defaultProps = {
+  name: '',
+  shippingAddress: {},
+  phoneNumber: '',
+  hasSelectedButton: false,
+  isButtonSelected: false,
+  onPressSelectedButton: () => {},
+  canEditAddress: false,
+  onPressSaveAddressForm: () => {},
+};
 
 const styles = StyleSheet.create({
   boxContainer: {
@@ -111,10 +163,15 @@ const styles = StyleSheet.create({
     flex: 3,
   },
   formContainer: {
-    paddingTop: 20,
-    paddingBottom: 20,
-    paddingLeft: 14,
-    paddingRight:14
+    paddingTop: 10,
+    paddingBottom: 10,
+    paddingLeft: 20,
+    paddingRight: 20,
+  },
+  formSaveButtonContainer: {
+    marginTop: 18,
+    marginBottom: 10,
+    alignItems: 'flex-end',
   },
   importantText: {
     ...commonStyles.fontRalewayBold,
@@ -127,16 +184,19 @@ const styles = StyleSheet.create({
     fontSize: 12,
     marginTop: 10,
   },
-  buttonContainer: {
+  selectButtonContainer: {
     flex: 2,
     paddingLeft: 4,
+  },
+  buttonTitleDefaultStyle: {
+    ...commonStyles.fontRalewaySemiBold,
+    fontSize: 14,
   },
   buttonDefaultStyle: {
     paddingTop: 4,
     paddingBottom: 4,
     width: 102,
     borderRadius: 16,
-    borderWidth: 1,
   },
   editIconContainer: {
     backgroundColor: Colors.mediumCarmine,
@@ -147,19 +207,12 @@ const styles = StyleSheet.create({
   },
   activeButton: {
     backgroundColor: Colors.mediumCarmine,
-    borderWidth: 0,
+  },
+  disabledButton: {
+    backgroundColor: Colors.darkGrey,
   },
   nonActiveButton: {
     borderColor: Colors.macaroniCheese,
+    borderWidth: 1,
   },
 });
-
-AddressSummary.propTypes = {
-  name: PropTypes.string,
-  shippingAddress: PropTypes.string,
-  phoneNumber: PropTypes.string,
-  hasSelectedButton: PropTypes.bool,
-  isButtonSelected: PropTypes.bool,
-  onPressButtonSelected: PropTypes.func,
-  canEditAddress: PropTypes.bool,
-};

--- a/front-end/constants/Colors.js
+++ b/front-end/constants/Colors.js
@@ -14,6 +14,7 @@ export default {
 
   white: '#fff',
   black: '#282828',
+  mediumBlack: '#595959',
   lightGrey: '#C4C4C4',
   darkGrey: '#979797',
   mediumCarmine: '#AA3C3B',


### PR DESCRIPTION
**Address Summary:**

![screen shot 2019-02-06 at 15 39 18](https://user-images.githubusercontent.com/26526772/52349548-7964f600-2a2f-11e9-856d-59c936e53f92.png)
<img width="382" alt="screen shot 2019-02-06 at 2 01 49" src="https://user-images.githubusercontent.com/26526772/52349559-7e29aa00-2a2f-11e9-8f05-780c5d0f577a.png">

On Click Edit button will open Address Form
How to use:

```javascript
          <AddressSummary
            name={'Thanh Dang'}
            shippingAddress={{
              address: 'Kotkantie 1',
              postCode: 90130,
              city: 'Oulu',
            }}
            phoneNumber={'+358469430446'}
            hasSelectedButton={true}
            isButtonSelected={false}
            canEditAddress={true}
            onPressSelectedButton={()=>{}}
            onPressSaveAddressForm={()=>{}}
          />
```

**Address Form:**
Only include the input field if use alone. Included in Address Summary as form field. 

![screen shot 2019-02-06 at 15 41 18](https://user-images.githubusercontent.com/26526772/52350074-70c0ef80-2a30-11e9-9fb8-db0d1d517434.png)

How to use
```javascript
              <AddressForm
                name={'Thanh Dang'}
                address={'Kotkantie 1'},
                postCode={90130},
                city={'Oulu'},
                phoneNumber={'+358469430446'}
                onAddressInputEndEditing={()=>{}}
              />
```