### PR TITLE
FE - Order history screen and its box component

### DIFF
--- a/front-end/components/OrderHistoryBox.js
+++ b/front-end/components/OrderHistoryBox.js
@@ -1,0 +1,126 @@
+import React from 'react';
+import { StyleSheet, View, Image, Text, TouchableOpacity } from 'react-native';
+import { Icon } from 'react-native-elements';
+import Colors from '../constants/Colors';
+import commonStyles from '../constants/commonStyles';
+import PropTypes from 'prop-types';
+
+
+export default function SubscriptionBox({ orderID, orderDate, orderPrice, isActive }) {
+  return (
+    <View
+      style={[
+        styles.boxContainer,
+        isActive ? styles.boxActive : styles.boxInactive,
+      ]}
+    >
+      <Image
+        source={require('../assets/images/slide4.png')}
+        style={styles.image}
+			/>
+			
+			<View style={styles.mainTextContainer}>
+				<Text style={styles.orderDate}>Date: {orderDate}</Text>
+				<Text style={styles.orderID}>Order ID: {orderID}</Text>
+			</View>
+			
+			<View style={styles.divider} />
+
+			<Text style={styles.orderPrice}>{orderPrice} €</Text>
+
+			<TouchableOpacity
+				style={styles.arrowIcon}
+			>
+				<Icon
+					name={'arrow-forward'}
+					size={21}
+					color={Colors.macaroniCheese}
+				/>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+SubscriptionBox.propTypes = {
+	orderDate: PropTypes.string,
+	orderID: PropTypes.number,
+	orderPrice: PropTypes.string,
+  isActive: PropTypes.bool,
+};
+
+SubscriptionBox.defaultProps = {
+	orderDate: '',
+	orderPrice: '',
+  isActive: true,
+};
+
+const styles = StyleSheet.create({
+	boxContainer: {
+		marginBottom: 21,
+		width: 347,
+		height: 87,
+		borderRadius: 11,
+
+		backgroundColor: Colors.white,
+		borderBottomWidth: 4,
+
+		shadowColor: Colors.darkGrey,
+		shadowOffset: { width: 0, height: 4 },
+		shadowOpacity: 0.25,
+		shadowRadius: 4,
+
+		flexDirection: 'row',
+		alignItems: 'center',
+		justifyContent: 'center',
+	},
+	boxActive: {
+    borderColor: Colors.macaroniCheese,
+  },
+  boxInactive: {
+    borderColor: Colors.lightGrey,
+	},
+	image: {
+		height: 53,
+		width: 71, 
+		marginLeft: 14,
+		marginBottom: 18,
+		marginTop: 16,
+	},
+	mainTextContainer: {
+		marginBottom: 26,
+		marginTop: 26,
+		marginLeft: 21,
+	},
+	orderID: {
+		...commonStyles.fontRalewayRegular,
+		...commonStyles.textGrey,
+		fontSize: 13,
+		marginTop: 5,
+	},
+	orderDate: {
+    ...commonStyles.fontRalewayBold,
+    ...commonStyles.textBlack,
+    fontSize: 14,
+    textTransform: 'uppercase',
+  },
+	divider: {
+		borderColor: '#E1E1E1',
+		height: 25,
+		borderWidth: 0.75,
+		marginRight: 18,
+		marginLeft: 12,
+		marginTop: 31,
+		marginBottom: 30,
+	},
+	orderPrice: {
+		...commonStyles.fontMontserratBold,
+		...commonStyles.textMediumCarmine,
+		fontSize: 16,
+		marginTop: 35,
+		marginBottom: 34,
+	},
+	arrowIcon: {
+		marginLeft: 18,
+		marginRight: 21,
+	},
+});

--- a/front-end/screens/MainScreens/OrderHistoryScreens/OrderHistoryScreen.js
+++ b/front-end/screens/MainScreens/OrderHistoryScreens/OrderHistoryScreen.js
@@ -1,18 +1,143 @@
 import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
-
-export default function OrderHistoryScreen(props) {
-  return (
-    <View style={styles.container}>
-      <Text>ORDER HISTORY</Text>
-    </View>
-  );
-}
+import { StyleSheet, Text, View, ScrollView } from 'react-native';
+import OrderHistoryBox from '../../../components/OrderHistoryBox';
+import Colors from '../../../constants/Colors';
+import commonStyles from '../../../constants/commonStyles';
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
   },
+  scrollContainerContent: {
+    alignItems: 'center',
+  },
+  textContainer: {
+    marginRight: 224,
+    marginLeft: 37,
+    marginTop: 45,
+		marginBottom: 58,
+  },
+  mainText: {
+		...commonStyles.fontRalewayBold,
+		...commonStyles.textMediumCarmine,
+		fontSize: 24,
+	},
 });
+
+
+export default class OrderHistoryScreen extends React.Component {
+
+  state = {
+    // Fetch order history? idk, just copied the mock data
+    // there's no price though, not sure how we're doing that one
+    // not sure what kind of date format would you want to have, so that's what it is for now
+    orderHistory: [
+      {
+        id: 123,
+        isActive: true,
+        subscriptions: [
+          {
+            id: 1,
+            title: 'Mixed',
+            isActive: true,
+          },
+          {
+            id: 2,
+            title: 'Vegan',
+            isActive: true,
+          },
+        ],
+        deliveryDayOfWeek: 'Tuesday',
+        deliveryTime: '10:00-12:00',
+        orderDate: '2019/02/02',
+      },
+      {
+        id: 124,
+        isActive: false,
+        subscriptions: [
+          {
+            id: 3,
+            title: 'Meat',
+            isActive: false,
+          },
+        ],
+        deliveryDayOfWeek: 'Wednesday',
+        deliveryTime: '16:00-18:00',
+        orderDate: '2019/02/08',
+      },
+    ],
+  };
+
+  renderOrderBoxes = () => {
+    return this.state.orderHistory.map(order => {
+      formattedDate = order.orderDate.replace(/\//g,'.');
+      return (
+          <OrderHistoryBox
+          key = {order.id}
+          orderID={order.id}
+          orderPrice={'388,00'}
+          orderDate={formattedDate}
+          isActive={order.isActive}
+        />
+
+        // not sure if the whole element has to be clickable or not, 
+        // I have just the arrow clickable atm, but it can easily be changed
+
+        // <TouchableOpacity
+        //   onPress={this.onPressOrderHistoryDetails}
+        //   key = {order.id}
+        // >
+        //   <OrderHistoryBox
+        //     key = {order.id}
+        //     orderID={order.id}
+        //     orderPrice={'388,00'}
+        //     orderDate={order.orderDate}
+        //     isActive={order.isActive}
+        //   />
+        // </TouchableOpacity>
+      );
+    });
+  };
+
+  render () {
+    return (
+      <ScrollView
+        contentContainerStyle={styles.scrollContainerContent}
+        style={styles.container}
+      >
+        <View style={styles.textContainer}>
+          <Text style={styles.mainText}>Order History</Text>
+        </View>
+        
+        <View styles={styles.boxesContainer}>
+          {this.renderOrderBoxes()}
+        </View>
+          
+      </ScrollView>
+    );
+  }
+
+  // didn't know which part did you want to be scrollable, so here's two variants
+  // there are ways to make the scroll cool, we could also make the active order sticky  
+  // but we don't have time for that stuff, so ayyy who even cares 
+
+  
+  // render () {
+  //   return (
+  //     <View style={styles.container}>
+  //
+  //       <View style={styles.textContainer}>
+  //         <Text style={styles.mainText}>Order History</Text>
+  //       </View>
+        
+  //       <ScrollView
+  //         showsVerticalScrollIndicator={false}
+  //         contentContainerStyle={styles.scrollContainerContent}
+  //       >
+  //         {this.renderOrderBoxes()}
+  //       </ScrollView>
+        
+  //     </View>
+  //   );
+  // }
+}


### PR DESCRIPTION
maname can't sleep 🛌 💤 

Things to consider: 
- the time format is a lil different, I wasn't sure if I had to swap day, year and month positions
- I wasn't sure if and what part of the page has to be scrollable, so I included two variants
- and I also wasn't sure if the whole box component has to be clickable, so I went with a clickable macaroni arrow ( but it's easy to change it, I included that case too )
- I sized the text just a few pixels different, it's barely noticeable, but I think it's easier to read that way, so check out if you like it